### PR TITLE
Add async and mocked-external unit tests

### DIFF
--- a/tests/ai/test_claude.py
+++ b/tests/ai/test_claude.py
@@ -1,14 +1,20 @@
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
 from ai.claude import ClaudeHandler
+from ai.config import DENJAMIN_SYSTEM_PROMPT
 
 
 @pytest.fixture
 def handler():
     with patch("ai.claude.AsyncAnthropic"):
-        return ClaudeHandler(api_key="fake-key")
+        h = ClaudeHandler(api_key="fake-key")
+    # Replace the client.messages.create with an AsyncMock after construction
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="bot reply")]
+    h.client.messages.create = AsyncMock(return_value=mock_response)
+    return h
 
 
 class TestCoalesceMessages:
@@ -89,3 +95,65 @@ class TestCoalesceMessages:
         # Second message is dropped because same-role branch doesn't append on isinstance failure
         assert len(result) == 1
         assert result[0]["content"] is image_block
+
+
+class TestGenerateResponse:
+    async def test_basic_response(self, handler):
+        result = await handler.generate_response("hi", None, [])
+        assert result == "bot reply"
+        handler.client.messages.create.assert_called_once()
+        call_kwargs = handler.client.messages.create.call_args.kwargs
+        assert call_kwargs["messages"] == [{"role": "user", "content": "hi"}]
+        assert call_kwargs["system"] == DENJAMIN_SYSTEM_PROMPT
+
+    async def test_with_conversation_context(self, handler):
+        context = [
+            {"role": "user", "content": "earlier"},
+            {"role": "assistant", "content": "response"},
+        ]
+        await handler.generate_response("follow up", context, [])
+        call_kwargs = handler.client.messages.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        assert len(messages) == 3
+        assert messages[0]["content"] == "earlier"
+        assert messages[1]["content"] == "response"
+        assert messages[2]["content"] == "follow up"
+
+    async def test_with_image_data(self, handler):
+        image_data = [{"type": "image", "source": {"type": "url", "url": "http://example.com/img.png"}}]
+        await handler.generate_response("describe this", None, image_data)
+        call_kwargs = handler.client.messages.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        assert content[0] == {"type": "text", "text": "describe this"}
+        assert content[1] == image_data[0]
+
+    async def test_with_context_and_images(self, handler):
+        context = [{"role": "assistant", "content": "hi there"}]
+        image_data = [{"type": "image", "source": {"type": "url", "url": "http://example.com/img.png"}}]
+        await handler.generate_response("look at this", context, image_data)
+        call_kwargs = handler.client.messages.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        assert len(messages) == 2
+        assert messages[0]["content"] == "hi there"
+        assert isinstance(messages[1]["content"], list)
+
+    async def test_api_error_returns_error_string(self, handler):
+        handler.client.messages.create = AsyncMock(side_effect=Exception("API down"))
+        result = await handler.generate_response("hi", None, [])
+        assert result == "Error: API down"
+
+    async def test_coalescing_applied(self, handler):
+        context = [{"role": "user", "content": "first message"}]
+        await handler.generate_response("second message", context, [])
+        call_kwargs = handler.client.messages.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        # Two consecutive user messages should be coalesced into one
+        assert len(messages) == 1
+        assert messages[0]["content"] == "first message\nsecond message"
+
+    async def test_default_model(self, handler):
+        await handler.generate_response("hi", None, [])
+        call_kwargs = handler.client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-20250514"

--- a/tests/discord_utils/test_messages.py
+++ b/tests/discord_utils/test_messages.py
@@ -1,6 +1,15 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 
-from discord_utils.messages import map_reply_chain_to_api_format
+import discord
+
+from discord_utils.messages import (
+    map_reply_chain_to_api_format,
+    fetch_reply_chain,
+    get_thread_history,
+    format_message_coversation,
+    CHAIN_LIMIT,
+)
+from tests.conftest import AsyncIteratorMock
 
 
 def _make_msg(content, bot=False):
@@ -36,3 +45,148 @@ class TestMapReplyChainToApiFormat:
     def test_content_preserved(self):
         result = map_reply_chain_to_api_format([_make_msg("exact content here")])
         assert result[0]["content"] == "exact content here"
+
+
+class TestGetThreadHistory:
+    async def test_returns_messages(self):
+        msgs = [_make_msg("a"), _make_msg("b"), _make_msg("c")]
+        thread = MagicMock(spec=discord.Thread)
+        thread.history.return_value = AsyncIteratorMock(msgs)
+        result = await get_thread_history(thread)
+        assert result == msgs
+
+    async def test_passes_chain_limit(self):
+        thread = MagicMock(spec=discord.Thread)
+        thread.history.return_value = AsyncIteratorMock([])
+        await get_thread_history(thread)
+        thread.history.assert_called_once_with(limit=CHAIN_LIMIT)
+
+
+class TestFetchReplyChain:
+    async def test_no_reference(self):
+        msg = MagicMock()
+        msg.channel = MagicMock(spec=discord.TextChannel)
+        msg.reference = None
+        chain, is_thread, count = await fetch_reply_chain(msg)
+        assert chain == []
+        assert is_thread is False
+        assert count == 0
+
+    async def test_single_reply(self):
+        parent = _make_msg("parent")
+        parent.reference = None
+
+        msg = MagicMock()
+        msg.channel = MagicMock(spec=discord.TextChannel)
+        msg.reference = MagicMock()
+        msg.reference.message_id = 111
+        msg.channel.fetch_message = AsyncMock(return_value=parent)
+
+        chain, is_thread, count = await fetch_reply_chain(msg)
+        assert len(chain) == 1
+        assert chain[0] is parent
+        assert is_thread is False
+        assert count == 1
+
+    async def test_deep_chain_reversed(self):
+        """A 3-deep reply chain should be returned oldest-first."""
+        channel = MagicMock(spec=discord.TextChannel)
+
+        msg_a = _make_msg("oldest")
+        msg_a.reference = None
+        msg_a.channel = channel
+
+        msg_b = _make_msg("middle")
+        msg_b.reference = MagicMock()
+        msg_b.reference.message_id = 100
+        msg_b.channel = channel
+
+        msg_c = _make_msg("newest parent")
+        msg_c.reference = MagicMock()
+        msg_c.reference.message_id = 101
+        msg_c.channel = channel
+
+        # First fetch returns msg_c (the direct parent), then msg_b, then msg_a
+        channel.fetch_message = AsyncMock(side_effect=[msg_c, msg_b, msg_a])
+
+        trigger = MagicMock()
+        trigger.channel = channel
+        trigger.reference = MagicMock()
+        trigger.reference.message_id = 102
+
+        chain, is_thread, count = await fetch_reply_chain(trigger)
+        assert [m.content for m in chain] == ["oldest", "middle", "newest parent"]
+        assert is_thread is False
+        assert count == 3
+
+    async def test_chain_limit_respected(self):
+        """Chain should stop at CHAIN_LIMIT even if more replies exist."""
+        channel = MagicMock(spec=discord.TextChannel)
+
+        # Build a chain longer than CHAIN_LIMIT
+        messages = []
+        for i in range(CHAIN_LIMIT + 5):
+            m = _make_msg(f"msg-{i}")
+            m.reference = MagicMock()
+            m.reference.message_id = 1000 + i
+            m.channel = channel
+            messages.append(m)
+        # Last message in chain has no reference
+        messages[-1].reference = None
+
+        channel.fetch_message = AsyncMock(side_effect=messages)
+
+        trigger = MagicMock()
+        trigger.channel = channel
+        trigger.reference = MagicMock()
+        trigger.reference.message_id = 999
+
+        chain, is_thread, count = await fetch_reply_chain(trigger)
+        assert len(chain) == CHAIN_LIMIT
+        assert count == CHAIN_LIMIT
+
+    async def test_thread_delegates_to_history(self):
+        thread_msgs = [_make_msg("t1"), _make_msg("t2")]
+        thread = MagicMock(spec=discord.Thread)
+        thread.history.return_value = AsyncIteratorMock(thread_msgs)
+
+        msg = MagicMock()
+        msg.channel = thread
+
+        chain, is_thread, count = await fetch_reply_chain(msg)
+        assert chain == thread_msgs
+        assert is_thread is True
+        assert count == -1
+
+
+class TestFormatMessageCoversation:
+    async def test_formats_reply_chain(self):
+        """Integration test: real internal calls, mocked Discord I/O."""
+        parent = _make_msg("parent question", bot=False)
+        parent.reference = None
+
+        msg = MagicMock()
+        msg.channel = MagicMock(spec=discord.TextChannel)
+        msg.reference = MagicMock()
+        msg.reference.message_id = 111
+        msg.channel.fetch_message = AsyncMock(return_value=parent)
+
+        formatted, is_thread, count = await format_message_coversation(msg)
+        assert len(formatted) == 1
+        assert formatted[0] == {"role": "user", "content": "parent question"}
+        assert is_thread is False
+        assert count == 1
+
+    async def test_thread_conversation(self):
+        thread_msgs = [_make_msg("user msg", bot=False), _make_msg("bot reply", bot=True)]
+        thread = MagicMock(spec=discord.Thread)
+        thread.history.return_value = AsyncIteratorMock(thread_msgs)
+
+        msg = MagicMock()
+        msg.channel = thread
+
+        formatted, is_thread, count = await format_message_coversation(msg)
+        assert len(formatted) == 2
+        assert formatted[0]["role"] == "user"
+        assert formatted[1]["role"] == "assistant"
+        assert is_thread is True

--- a/tests/points/test_repository.py
+++ b/tests/points/test_repository.py
@@ -1,0 +1,83 @@
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def repo_and_mocks(mock_db):
+    db, mock_conn = mock_db
+    mock_queries = MagicMock()
+
+    with patch.dict(sys.modules, {"points.repository": None}):
+        with patch("aiosql.from_path", return_value=mock_queries):
+            # Force re-import so aiosql.from_path is intercepted
+            if "points.repository" in sys.modules:
+                del sys.modules["points.repository"]
+
+            from points.repository import PointsRepository
+
+            repo = PointsRepository(db)
+            # Bind the mock_queries to the module's queries reference
+            import points.repository as repo_module
+            repo_module.queries = mock_queries
+
+            yield repo, mock_queries, mock_conn
+
+
+class TestUpdatePoints:
+    def test_new_user_inserts(self, repo_and_mocks):
+        repo, mock_queries, mock_conn = repo_and_mocks
+        mock_queries.get_user_points.return_value = None
+
+        result = repo.update_points(123, "user#0001", "User", 10)
+
+        mock_queries.insert_user.assert_called_once_with(
+            mock_conn, user_id=123, username="user#0001", display_name="User", points=10
+        )
+        assert result == 10
+
+    def test_existing_user_updates(self, repo_and_mocks):
+        repo, mock_queries, mock_conn = repo_and_mocks
+        mock_queries.get_user_points.return_value = (50,)
+
+        result = repo.update_points(123, "user#0001", "User", 20)
+
+        mock_queries.update_user_points.assert_called_once_with(
+            mock_conn, points=70, display_name="User", user_id=123
+        )
+        assert result == 70
+
+    def test_negative_points(self, repo_and_mocks):
+        repo, mock_queries, mock_conn = repo_and_mocks
+        mock_queries.get_user_points.return_value = (50,)
+
+        result = repo.update_points(123, "user#0001", "User", -30)
+
+        mock_queries.update_user_points.assert_called_once_with(
+            mock_conn, points=20, display_name="User", user_id=123
+        )
+        assert result == 20
+
+    def test_returns_new_total(self, repo_and_mocks):
+        repo, mock_queries, mock_conn = repo_and_mocks
+        mock_queries.get_user_points.return_value = (100,)
+
+        result = repo.update_points(123, "user#0001", "User", 5)
+        assert result == 105
+
+
+class TestGetLeaderboard:
+    def test_returns_rows(self, repo_and_mocks):
+        repo, mock_queries, mock_conn = repo_and_mocks
+        mock_queries.get_leaderboard.return_value = [(1, 100), (2, 50)]
+
+        result = repo.get_leaderboard()
+        assert result == [(1, 100), (2, 50)]
+
+    def test_empty(self, repo_and_mocks):
+        repo, mock_queries, mock_conn = repo_and_mocks
+        mock_queries.get_leaderboard.return_value = []
+
+        result = repo.get_leaderboard()
+        assert result == []


### PR DESCRIPTION
## Summary
- 7 tests for `ClaudeHandler.generate_response` — message assembly with/without context and images, API error handling, coalescing verification, default model
- 9 tests for async discord_utils functions — `get_thread_history`, `fetch_reply_chain` (no reference, single reply, deep chain reversal, CHAIN_LIMIT, thread delegation), `format_message_coversation` integration
- 6 tests for `PointsRepository` — new user insert vs existing user update, negative points, return values, leaderboard queries

**Technical note:** `points.repository` loads aiosql queries at import time, requiring `aiosql.from_path` to be patched before the module imports. The fixture uses `patch.dict(sys.modules)` + forced re-import to handle this cleanly.

Part 3 of 4 for #11. Running total: 43 tests passing.

## Test plan
- [x] `pytest -v` — all 43 tests pass (21 prior + 22 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)