### PR TITLE
Add bot client, commands, and database unit tests

### DIFF
--- a/tests/bot/test_client.py
+++ b/tests/bot/test_client.py
@@ -1,0 +1,144 @@
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from bot.client import MyBot, create_bot, REPLY_LIMIT
+
+
+@pytest.fixture
+def bot_and_mocks():
+    mock_chatbot = AsyncMock()
+    mock_chatbot.generate_response = AsyncMock(return_value="bot reply")
+    mock_points_repo = MagicMock()
+
+    with patch("bot.client.register_points_commands"):
+        bot = MyBot(mock_chatbot, mock_points_repo)
+
+    # discord.Client.user is a read-only property, so we patch it on the class
+    mock_user = MagicMock()
+    mock_user.id = 12345
+    with patch.object(type(bot), "user", new_callable=lambda: property(lambda self: mock_user)):
+        yield bot, mock_chatbot
+
+
+class TestOnMessage:
+    async def test_ignores_own_messages(self, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        message = MagicMock()
+        message.author = bot.user
+
+        await bot.on_message(message)
+
+        mock_chatbot.generate_response.assert_not_called()
+
+    async def test_ignores_no_mention(self, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        message = MagicMock()
+        message.author = MagicMock()
+        message.mentions = []
+
+        await bot.on_message(message)
+
+        mock_chatbot.generate_response.assert_not_called()
+
+    @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
+    @patch("bot.client.format_attachment_data")
+    async def test_replies_in_thread(self, mock_attachments, mock_conversation, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        mock_attachments.return_value = []
+        mock_conversation.return_value = ([], True, -1)
+
+        message = MagicMock()
+        message.author = MagicMock()
+        message.mentions = [bot.user]
+        message.content = f"<@{bot.user.id}> hello"
+        message.channel.send = AsyncMock()
+
+        await bot.on_message(message)
+
+        message.channel.send.assert_called_once_with("bot reply")
+        message.reply.assert_not_called()
+
+    @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
+    @patch("bot.client.format_attachment_data")
+    async def test_replies_normally_under_limit(self, mock_attachments, mock_conversation, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        mock_attachments.return_value = []
+        mock_conversation.return_value = ([], False, 3)
+
+        message = MagicMock()
+        message.author = MagicMock()
+        message.mentions = [bot.user]
+        message.content = f"<@{bot.user.id}> hello"
+        message.reply = AsyncMock()
+
+        await bot.on_message(message)
+
+        message.reply.assert_called_once_with("bot reply")
+
+    @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
+    @patch("bot.client.format_attachment_data")
+    async def test_creates_thread_over_limit(self, mock_attachments, mock_conversation, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        mock_attachments.return_value = []
+        mock_conversation.return_value = ([], False, REPLY_LIMIT + 1)
+
+        mock_thread = MagicMock()
+        mock_thread.send = AsyncMock()
+
+        message = MagicMock()
+        message.author = MagicMock()
+        message.author.display_name = "TestUser"
+        message.mentions = [bot.user]
+        message.content = f"<@{bot.user.id}> hello"
+        message.create_thread = AsyncMock(return_value=mock_thread)
+
+        await bot.on_message(message)
+
+        message.create_thread.assert_called_once_with(name="Conversation with TestUser")
+        mock_thread.send.assert_called_once_with("bot reply")
+        message.reply.assert_not_called()
+
+    @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
+    @patch("bot.client.format_attachment_data")
+    async def test_strips_mention_from_input(self, mock_attachments, mock_conversation, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        mock_attachments.return_value = []
+        mock_conversation.return_value = ([], False, 0)
+
+        message = MagicMock()
+        message.author = MagicMock()
+        message.mentions = [bot.user]
+        message.content = f"<@{bot.user.id}> what is a den?"
+        message.reply = AsyncMock()
+
+        await bot.on_message(message)
+
+        call_args = mock_chatbot.generate_response.call_args
+        assert call_args[0][0] == "what is a den?"
+
+    @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
+    @patch("bot.client.format_attachment_data")
+    async def test_error_sends_to_channel(self, mock_attachments, mock_conversation, bot_and_mocks):
+        bot, mock_chatbot = bot_and_mocks
+        mock_attachments.return_value = []
+        mock_conversation.return_value = ([], False, 0)
+        mock_chatbot.generate_response = AsyncMock(side_effect=Exception("something broke"))
+
+        message = MagicMock()
+        message.author = MagicMock()
+        message.mentions = [bot.user]
+        message.content = f"<@{bot.user.id}> hello"
+        message.channel.send = AsyncMock()
+
+        await bot.on_message(message)
+
+        message.channel.send.assert_called_once()
+        assert "something broke" in message.channel.send.call_args[0][0]
+
+
+class TestCreateBot:
+    @patch("bot.client.register_points_commands")
+    def test_returns_mybot_instance(self, mock_register):
+        bot = create_bot(MagicMock(), MagicMock())
+        assert isinstance(bot, MyBot)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,13 @@
+from unittest.mock import MagicMock, AsyncMock, patch
+
+# Patch aiosql.from_path before any test module imports points.repository,
+# which calls aiosql.from_path at module level. The locally installed aiosql
+# version may be incompatible with the project's SQL syntax, so we replace
+# the call with a MagicMock to avoid parse errors during test collection.
+_aiosql_patcher = patch("aiosql.from_path", return_value=MagicMock())
+_aiosql_patcher.start()
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock
 
 
 class AsyncIteratorMock:

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch, MagicMock
+
+from db.connection import Database
+
+
+class TestDatabase:
+    @patch("db.connection.SimpleConnectionPool")
+    def test_connection_yields_and_returns(self, mock_pool_cls):
+        mock_pool = MagicMock()
+        mock_conn = MagicMock()
+        mock_pool.getconn.return_value = mock_conn
+        mock_pool_cls.return_value = mock_pool
+
+        db = Database("postgres://fake")
+
+        with db.connection() as conn:
+            assert conn is mock_conn
+
+        mock_pool.getconn.assert_called_once()
+        mock_pool.putconn.assert_called_once_with(mock_conn)
+
+    @patch("db.connection.SimpleConnectionPool")
+    def test_close_calls_closeall(self, mock_pool_cls):
+        mock_pool = MagicMock()
+        mock_pool_cls.return_value = mock_pool
+
+        db = Database("postgres://fake")
+        db.close()
+
+        mock_pool.closeall.assert_called_once()

--- a/tests/points/test_commands.py
+++ b/tests/points/test_commands.py
@@ -1,0 +1,117 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import discord
+
+from points.commands import register_points_commands
+
+
+@pytest.fixture
+def commands_setup():
+    """Register commands on a mock bot and return the callbacks + mocked repo."""
+    mock_points_repo = MagicMock()
+
+    registered_commands = {}
+
+    mock_bot = MagicMock()
+
+    def fake_command(**kwargs):
+        def decorator(func):
+            registered_commands[kwargs["name"]] = func
+            return func
+        return decorator
+
+    mock_bot.tree.command = fake_command
+
+    register_points_commands(mock_bot, mock_points_repo)
+
+    return registered_commands, mock_points_repo
+
+
+def _make_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+def _make_member(user_id=123, name="user#0001", display_name="User"):
+    member = MagicMock(spec=discord.Member)
+    member.id = user_id
+    member.__str__ = MagicMock(return_value=name)
+    member.display_name = display_name
+    member.mention = f"<@{user_id}>"
+    return member
+
+
+class TestUpdatePoints:
+    async def test_positive_points(self, commands_setup):
+        commands, mock_repo = commands_setup
+        mock_repo.update_points.return_value = 10
+        interaction = _make_interaction()
+        member = _make_member()
+
+        await commands["updatepoints"](interaction, member, 10)
+
+        response = interaction.response.send_message.call_args[0][0]
+        assert "Added" in response
+        assert "10 points" in response
+
+    async def test_negative_points(self, commands_setup):
+        commands, mock_repo = commands_setup
+        mock_repo.update_points.return_value = 45
+        interaction = _make_interaction()
+        member = _make_member()
+
+        await commands["updatepoints"](interaction, member, -5)
+
+        response = interaction.response.send_message.call_args[0][0]
+        assert "Subtracted" in response
+        assert "5 points" in response
+
+    async def test_error_handling(self, commands_setup):
+        commands, mock_repo = commands_setup
+        mock_repo.update_points.side_effect = Exception("db error")
+        interaction = _make_interaction()
+        member = _make_member()
+
+        await commands["updatepoints"](interaction, member, 10)
+
+        response = interaction.response.send_message.call_args[0][0]
+        assert "error" in response.lower()
+        assert "db error" in response
+
+
+class TestLeaderboard:
+    async def test_empty_leaderboard(self, commands_setup):
+        commands, mock_repo = commands_setup
+        mock_repo.get_leaderboard.return_value = []
+        interaction = _make_interaction()
+
+        await commands["leaderboard"](interaction)
+
+        response = interaction.response.send_message.call_args[0][0]
+        assert "No points have been awarded yet!" in response
+
+    async def test_populated_leaderboard(self, commands_setup):
+        commands, mock_repo = commands_setup
+        mock_repo.get_leaderboard.return_value = [(1, 100), (2, 50)]
+        interaction = _make_interaction()
+
+        await commands["leaderboard"](interaction)
+
+        response = interaction.response.send_message.call_args[0][0]
+        assert "Leaderboard" in response
+        assert "<@1>: 100 points" in response
+        assert "<@2>: 50 points" in response
+
+    async def test_error_handling(self, commands_setup):
+        commands, mock_repo = commands_setup
+        mock_repo.get_leaderboard.side_effect = Exception("db error")
+        interaction = _make_interaction()
+
+        await commands["leaderboard"](interaction)
+
+        response = interaction.response.send_message.call_args[0][0]
+        assert "error" in response.lower()
+        assert "db error" in response


### PR DESCRIPTION
## Summary
- 8 tests for `MyBot` — self-message ignore, no-mention ignore, thread reply, normal reply under limit, thread creation over REPLY_LIMIT, mention stripping, error forwarding, `create_bot` return type
- 6 tests for points slash commands — positive/negative updatepoints, empty/populated leaderboard, error handling for both
- 2 tests for `Database` — connection context manager yields/returns conn, close calls closeall
- Updated `tests/conftest.py` to patch `aiosql.from_path` at collection time, preventing import errors from local aiosql version mismatch

**Technical notes:**
- `discord.Client.user` is a read-only property — used `patch.object(type(bot), "user", ...)` to mock it
- Slash command callbacks extracted by capturing them via a fake `bot.tree.command` decorator during `register_points_commands`

Part 4 of 4 for #11. **Full suite: 59 tests passing.** This completes the unit testing initiative.

## Test plan
- [x] `pytest -v` — all 59 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)