### PR TITLE
Add Docker support for local dev and production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+.env
+__pycache__/
+.git/
+tests/

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Discord bot token — get from Discord Developer Portal
 BOT_TOKEN=
 
-# PostgreSQL connection string (e.g. postgresql://user:pass@localhost:5432/denbot)
+# PostgreSQL connection string (e.g. postgresql://denbot:denbot@localhost:5432/denbot)
 DATABASE_URL=
 
 # Anthropic API key — get from console.anthropic.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "denjamin.py"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ This is a discord bot that will help you and your friends increase your denlines
 
    The bot connects outbound to Discord's websocket gateway — no port forwarding or tunnels needed.
 
+## Docker
+
+Instead of installing PostgreSQL locally, you can use Docker:
+
+**Start Postgres for local dev** (bot runs on your machine):
+
+```bash
+docker-compose up -d
+```
+
+This starts Postgres on `localhost:5432` and auto-creates the `points` table. Set your `DATABASE_URL` to `postgresql://denbot:denbot@localhost:5432/denbot`.
+
+**Run everything in containers** (Postgres + bot):
+
+```bash
+docker-compose --profile bot up
+```
+
+**Tear down and remove data:**
+
+```bash
+docker-compose down -v
+```
+
 ## Creating a Discord Test Bot
 
 1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) and click **New Application**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: denbot
+      POSTGRES_USER: denbot
+      POSTGRES_PASSWORD: denbot
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./db/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U denbot"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  bot:
+    build: .
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+    profiles:
+      - bot
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with Postgres 16 service (auto-schema creation) and a `bot` profile for full-stack containerized runs
- Add `Dockerfile` using `python:3.12-slim` with layer-cached dependency install
- Add `.dockerignore` to exclude `venv/`, `.env`, `__pycache__/`, `.git/`, `tests/`
- Add Docker section to README documenting both usage patterns
- Update `.env.example` connection string to match docker-compose defaults

Closes #32

## Test plan
- [ ] `docker-compose up -d` starts Postgres and auto-creates the points table
- [ ] `python denjamin.py` on host connects to Dockerized Postgres with `DATABASE_URL=postgresql://denbot:denbot@localhost:5432/denbot`
- [ ] `docker-compose --profile bot up` runs both Postgres and bot in containers
- [ ] `docker-compose down -v` tears down cleanly
- [ ] `.dockerignore` excludes expected files from image

🤖 Generated with [Claude Code](https://claude.com/claude-code)