### PR TITLE
Add python-dotenv to auto-load .env file

### DIFF
--- a/denjamin.py
+++ b/denjamin.py
@@ -1,5 +1,8 @@
 import os
 
+from dotenv import load_dotenv
+load_dotenv()
+
 from ai import ClaudeHandler
 from db import Database
 from points import PointsRepository

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,5 +81,6 @@ wcwidth==0.2.13
 webencodings==0.5.1
 yarg==0.1.9
 yarl==1.18.3
+python-dotenv>=1.0
 pytest>=8.0
 pytest-asyncio>=0.23


### PR DESCRIPTION
## Summary
- Adds `python-dotenv` to `requirements.txt` and calls `load_dotenv()` in `denjamin.py` before any `os.getenv()` calls
- Local dev now only requires `cp .env.example .env` + filling in values — no manual `export` needed
- No-op when env vars are already set (Docker, cloud platforms)

Closes #37

## Test plan
- [x] All 59 existing tests pass
- [ ] Verify bot starts with only a `.env` file (no manual exports)
- [ ] Verify bot still works via `docker-compose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)