### PR TITLE
Fix aiosql v13 query syntax

### DIFF
--- a/points/sql/points.sql
+++ b/points/sql/points.sql
@@ -1,11 +1,11 @@
--- name: get_user_points :one
+-- name: get_user_points^
 SELECT points FROM points WHERE user_id = :user_id;
 
--- name: update_user_points :affected
+-- name: update_user_points$
 UPDATE points SET points = :points, display_name = :display_name WHERE user_id = :user_id;
 
--- name: insert_user :exec
+-- name: insert_user!
 INSERT INTO points (user_id, username, display_name, points) VALUES (:user_id, :username, :display_name, :points);
 
--- name: get_leaderboard :many
+-- name: get_leaderboard
 SELECT user_id, points FROM points ORDER BY points DESC;


### PR DESCRIPTION
## Summary
- Updates SQL query operation specs in `points/sql/points.sql` to use aiosql v13 symbol syntax (`^`, `$`, `!`) instead of the deprecated word syntax (`:one`, `:affected`, `:exec`)
- Fixes `SQLParseException` when running the bot locally with aiosql >= 13

## Test plan
- [x] All 59 tests pass
- [ ] Bot starts successfully with `python denjamin.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)