### PR TITLE
Add automatic database reconnection

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -5,12 +5,21 @@ from psycopg2.pool import SimpleConnectionPool
 
 class Database:
     def __init__(self, database_url):
+        self.database_url = database_url
         self.pool = SimpleConnectionPool(minconn=1, maxconn=3, dsn=database_url)
+
+    def _ensure_pool(self):
+        if self.pool.closed:
+            self.pool = SimpleConnectionPool(minconn=1, maxconn=3, dsn=self.database_url)
 
     @contextmanager
     def connection(self):
+        self._ensure_pool()
         conn = self.pool.getconn()
         try:
+            if conn.closed:
+                self.pool.putconn(conn, close=True)
+                conn = self.pool.getconn()
             with conn:
                 yield conn
         finally:

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -8,6 +8,7 @@ class TestDatabase:
     def test_connection_yields_and_returns(self, mock_pool_cls):
         mock_pool = MagicMock()
         mock_conn = MagicMock()
+        mock_conn.closed = 0
         mock_pool.getconn.return_value = mock_conn
         mock_pool_cls.return_value = mock_pool
 


### PR DESCRIPTION
## Summary
- Detects stale connections (`conn.closed`) before use and replaces them with fresh ones
- Recreates the connection pool if it's been fully closed
- Bot now recovers gracefully from Postgres restarts without needing to be restarted itself

## Test plan
- [x] All 59 tests pass
- [ ] Start bot, restart Postgres container (`docker-compose restart db`), verify bot handles next query without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)