### PR TITLE
Add graceful shutdown and structured logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+STOPSIGNAL SIGTERM
 CMD ["python", "denjamin.py"]

--- a/bot/client.py
+++ b/bot/client.py
@@ -1,27 +1,53 @@
+import logging
+
 import discord
 
 from discord_utils import format_attachment_data, format_message_coversation
 from points import register_points_commands
 
+logger = logging.getLogger(__name__)
+
 REPLY_LIMIT = 5
 
 
 class MyBot(discord.Client):
-    def __init__(self, chatbot, points_repo):
+    def __init__(self, chatbot, points_repo, db):
         intents = discord.Intents.default()
         intents.message_content = True
         super().__init__(intents=intents)
         self.tree = discord.app_commands.CommandTree(self)
         self.chatbot = chatbot
+        self.db = db
 
         register_points_commands(self, points_repo)
+
+    async def setup_hook(self):
+        logger.info("Bot starting up, verifying database connectivity...")
+        try:
+            with self.db.connection() as conn:
+                cur = conn.cursor()
+                cur.execute("SELECT 1")
+                cur.close()
+            logger.info("Database connectivity verified.")
+        except Exception:
+            logger.exception("Database connectivity check failed during startup")
 
     async def on_ready(self):
         try:
             await self.tree.sync()
-            print(f"Logged in as {self.user} and synced commands!")
+            logger.info("Logged in as %s and synced commands!", self.user)
         except Exception as e:
-            print(f"Failed to sync commands: {e}")
+            logger.error("Failed to sync commands: %s", e)
+
+    async def close(self):
+        logger.info("Shutdown initiated, cleaning up resources...")
+        try:
+            self.db.close()
+            logger.info("Database pool closed.")
+        except Exception:
+            logger.exception("Error closing database pool")
+        await super().close()
+        logger.info("Discord client closed.")
 
     async def on_message(self, message):
         # Ignore messages from the bot itself
@@ -53,5 +79,5 @@ class MyBot(discord.Client):
                 await message.channel.send(f"Error: {e}")
 
 
-def create_bot(chatbot, points_repo):
-    return MyBot(chatbot, points_repo)
+def create_bot(chatbot, points_repo, db):
+    return MyBot(chatbot, points_repo, db)

--- a/denjamin.py
+++ b/denjamin.py
@@ -1,7 +1,13 @@
+import logging
 import os
 
 from dotenv import load_dotenv
 load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
 
 from ai import ClaudeHandler
 from db import Database
@@ -14,5 +20,5 @@ db = Database(os.getenv("DATABASE_URL"))
 points_repo = PointsRepository(db)
 
 # Create and run the bot
-bot = create_bot(chatbot, points_repo)
+bot = create_bot(chatbot, points_repo, db)
 bot.run(os.getenv("BOT_TOKEN"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
   bot:
     build: .
     env_file: .env
+    stop_grace_period: 10s
     depends_on:
       db:
         condition: service_healthy

--- a/tests/bot/test_client.py
+++ b/tests/bot/test_client.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from bot.client import MyBot, create_bot, REPLY_LIMIT
@@ -10,20 +11,21 @@ def bot_and_mocks():
     mock_chatbot = AsyncMock()
     mock_chatbot.generate_response = AsyncMock(return_value="bot reply")
     mock_points_repo = MagicMock()
+    mock_db = MagicMock()
 
     with patch("bot.client.register_points_commands"):
-        bot = MyBot(mock_chatbot, mock_points_repo)
+        bot = MyBot(mock_chatbot, mock_points_repo, mock_db)
 
     # discord.Client.user is a read-only property, so we patch it on the class
     mock_user = MagicMock()
     mock_user.id = 12345
     with patch.object(type(bot), "user", new_callable=lambda: property(lambda self: mock_user)):
-        yield bot, mock_chatbot
+        yield bot, mock_chatbot, mock_db
 
 
 class TestOnMessage:
     async def test_ignores_own_messages(self, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         message = MagicMock()
         message.author = bot.user
 
@@ -32,7 +34,7 @@ class TestOnMessage:
         mock_chatbot.generate_response.assert_not_called()
 
     async def test_ignores_no_mention(self, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         message = MagicMock()
         message.author = MagicMock()
         message.mentions = []
@@ -44,7 +46,7 @@ class TestOnMessage:
     @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
     @patch("bot.client.format_attachment_data")
     async def test_replies_in_thread(self, mock_attachments, mock_conversation, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         mock_attachments.return_value = []
         mock_conversation.return_value = ([], True, -1)
 
@@ -62,7 +64,7 @@ class TestOnMessage:
     @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
     @patch("bot.client.format_attachment_data")
     async def test_replies_normally_under_limit(self, mock_attachments, mock_conversation, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         mock_attachments.return_value = []
         mock_conversation.return_value = ([], False, 3)
 
@@ -79,7 +81,7 @@ class TestOnMessage:
     @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
     @patch("bot.client.format_attachment_data")
     async def test_creates_thread_over_limit(self, mock_attachments, mock_conversation, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         mock_attachments.return_value = []
         mock_conversation.return_value = ([], False, REPLY_LIMIT + 1)
 
@@ -102,7 +104,7 @@ class TestOnMessage:
     @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
     @patch("bot.client.format_attachment_data")
     async def test_strips_mention_from_input(self, mock_attachments, mock_conversation, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         mock_attachments.return_value = []
         mock_conversation.return_value = ([], False, 0)
 
@@ -120,7 +122,7 @@ class TestOnMessage:
     @patch("bot.client.format_message_coversation", new_callable=AsyncMock)
     @patch("bot.client.format_attachment_data")
     async def test_error_sends_to_channel(self, mock_attachments, mock_conversation, bot_and_mocks):
-        bot, mock_chatbot = bot_and_mocks
+        bot, mock_chatbot, mock_db = bot_and_mocks
         mock_attachments.return_value = []
         mock_conversation.return_value = ([], False, 0)
         mock_chatbot.generate_response = AsyncMock(side_effect=Exception("something broke"))
@@ -137,8 +139,23 @@ class TestOnMessage:
         assert "something broke" in message.channel.send.call_args[0][0]
 
 
+class TestClose:
+    async def test_close_calls_db_close(self, bot_and_mocks):
+        bot, _, mock_db = bot_and_mocks
+        with patch.object(discord.Client, "close", new_callable=AsyncMock):
+            await bot.close()
+        mock_db.close.assert_called_once()
+
+    async def test_close_still_closes_discord_on_db_error(self, bot_and_mocks):
+        bot, _, mock_db = bot_and_mocks
+        mock_db.close.side_effect = Exception("pool error")
+        with patch.object(discord.Client, "close", new_callable=AsyncMock) as mock_super_close:
+            await bot.close()
+        mock_super_close.assert_called_once()
+
+
 class TestCreateBot:
     @patch("bot.client.register_points_commands")
     def test_returns_mybot_instance(self, mock_register):
-        bot = create_bot(MagicMock(), MagicMock())
+        bot = create_bot(MagicMock(), MagicMock(), MagicMock())
         assert isinstance(bot, MyBot)


### PR DESCRIPTION
## Summary
- Override `close()` on the bot client to drain the DB connection pool before closing the Discord websocket on SIGTERM/SIGINT
- Add `setup_hook()` to verify database connectivity at startup
- Replace `print()` with Python stdlib `logging` for structured, timestamped output
- Add explicit `STOPSIGNAL SIGTERM` in Dockerfile and `stop_grace_period: 10s` in docker-compose

Closes #40

## Test plan
- [x] All 61 tests pass, including 2 new `TestClose` tests
- [ ] Manual: `docker-compose --profile bot up` then `docker-compose down` — verify logs show shutdown sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)