### PR TITLE
Fix silent message drop in _coalesce_messages for non-string content

### DIFF
--- a/ai/claude.py
+++ b/ai/claude.py
@@ -57,6 +57,8 @@ class ClaudeHandler:
                 new_content = msg["content"]
                 if isinstance(prev_content, str) and isinstance(new_content, str):
                     coalesced[-1]["content"] = prev_content + "\n" + new_content
+                else:
+                    coalesced.append(msg.copy())
             else:
                 coalesced.append(msg.copy())
         return coalesced

--- a/tests/ai/test_claude.py
+++ b/tests/ai/test_claude.py
@@ -82,19 +82,17 @@ class TestCoalesceMessages:
         assert msgs[1] == original_second
 
     def test_non_string_content_not_merged(self, handler):
-        """When both consecutive same-role messages have string content, they merge.
-        When either has non-string content (e.g. image blocks), the isinstance check
-        prevents merging — but the current implementation also drops the second message
-        since it's neither merged nor appended. This test documents that behavior."""
+        """When consecutive same-role messages can't be string-merged (e.g. one has
+        image blocks), both messages are preserved rather than silently dropped."""
         image_block = [{"type": "image", "source": {"type": "url", "url": "http://example.com/img.png"}}]
         msgs = [
             {"role": "user", "content": image_block},
             {"role": "user", "content": "describe it"},
         ]
         result = handler._coalesce_messages(msgs)
-        # Second message is dropped because same-role branch doesn't append on isinstance failure
-        assert len(result) == 1
+        assert len(result) == 2
         assert result[0]["content"] is image_block
+        assert result[1]["content"] == "describe it"
 
 
 class TestGenerateResponse:


### PR DESCRIPTION
## Summary
- `_coalesce_messages` silently dropped the second of two consecutive same-role messages when the `isinstance(str, str)` merge check failed (e.g. one side is a list of image blocks).
- Added an `else` branch to append the message in that case, preserving it for the API call.
- Updated `test_non_string_content_not_merged` (previously documenting the buggy behavior) to assert both messages are preserved.

Closes #26.

## Test plan
- [x] `pytest tests/ai/test_claude.py` — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)