### PR TITLE
Add self-hosted Temporal stack for workflow orchestration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,21 @@ DATABASE_URL=
 
 # Anthropic API key — get from console.anthropic.com
 ANTHROPIC_API_KEY=
+
+# ----- Temporal (optional) -----
+# Leave TEMPORAL_ADDRESS blank to disable Temporal entirely. When set, the bot
+# will connect a Temporal client at startup; the worker process always expects
+# these to be populated.
+#
+# For local dev with docker-compose --profile temporal up:
+#   TEMPORAL_ADDRESS=localhost:7233
+#   TEMPORAL_NAMESPACE=default
+#   TEMPORAL_TASK_QUEUE=denjamin-main
+TEMPORAL_ADDRESS=
+TEMPORAL_NAMESPACE=default
+TEMPORAL_TASK_QUEUE=denjamin-main
+
+# Optional mTLS for production self-hosted Temporal. Paths inside the
+# container. Leave blank for plaintext gRPC (fine on a private network).
+TEMPORAL_TLS_CERT_PATH=
+TEMPORAL_TLS_KEY_PATH=

--- a/README.md
+++ b/README.md
@@ -83,6 +83,53 @@ docker-compose --profile bot up
 docker-compose down -v
 ```
 
+## Temporal (workflow orchestration)
+
+Denjamin ships with an opt-in Temporal stack for durable workflow execution. Temporal is gated behind a docker-compose profile so it only runs when you ask for it.
+
+**Bring up the full Temporal stack** (server, UI, its own Postgres, and a worker):
+
+```bash
+docker-compose --profile temporal up
+```
+
+- gRPC frontend: `localhost:7233`
+- Web UI: [http://localhost:8080](http://localhost:8080)
+
+**Run just Temporal without the bot or worker** (useful when developing workflows from a REPL):
+
+```bash
+docker-compose up temporal temporal-ui temporal-postgres
+```
+
+**Enable the Temporal client in the bot** by setting `TEMPORAL_ADDRESS` in your `.env`:
+
+```
+TEMPORAL_ADDRESS=localhost:7233
+TEMPORAL_NAMESPACE=default
+TEMPORAL_TASK_QUEUE=denjamin-main
+```
+
+Leave `TEMPORAL_ADDRESS` blank to disable Temporal entirely — the bot will run as before.
+
+**Run the worker locally** (instead of in a container):
+
+```bash
+python temporal_worker.py
+```
+
+The worker and the Discord bot ship from the **same Docker image**; only the entrypoint differs. Scale workers horizontally in production by running more `temporal-worker` containers — Temporal distributes task-queue work across them automatically.
+
+### Production notes (self-hosted)
+
+The `temporalio/auto-setup` image we use for dev is explicitly not recommended by Temporal for production. For a productionized self-hosted deployment (e.g., on a Raspberry Pi 4/5 or similar single-node host):
+
+- Replace `auto-setup` with separate `frontend`, `history`, `matching`, and `internal-frontend` services using the `temporalio/server` image, and run `temporalio/admin-tools` once as a schema-setup job.
+- Keep Temporal's Postgres isolated from the application's Postgres (this repo's compose already does).
+- Set `TEMPORAL_TLS_CERT_PATH` / `TEMPORAL_TLS_KEY_PATH` and mount mTLS certs if the worker/client traverse an untrusted network; plaintext gRPC is fine when everything runs on the same private bridge network.
+- Expected resource baseline: ~700MB–1GB RAM idle for the Temporal services + their Postgres. A Pi 4 with 4GB+ or Pi 5 is recommended; Pi Zero will not work.
+- All `temporalio/*` images publish `linux/arm64` variants, so ARM hosts are supported.
+
 ## Creating a Discord Test Bot
 
 1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) and click **New Application**

--- a/bot/client.py
+++ b/bot/client.py
@@ -11,13 +11,17 @@ REPLY_LIMIT = 5
 
 
 class MyBot(discord.Client):
-    def __init__(self, chatbot, points_repo, db):
+    def __init__(self, chatbot, points_repo, db, temporal_config=None):
         intents = discord.Intents.default()
         intents.message_content = True
         super().__init__(intents=intents)
         self.tree = discord.app_commands.CommandTree(self)
         self.chatbot = chatbot
         self.db = db
+        self.temporal_config = temporal_config
+        # Populated lazily in setup_hook(); None means Temporal is disabled
+        # or the initial connection failed.
+        self.temporal_client = None
 
         register_points_commands(self, points_repo)
 
@@ -31,6 +35,25 @@ class MyBot(discord.Client):
             logger.info("Database connectivity verified.")
         except Exception:
             logger.exception("Database connectivity check failed during startup")
+
+        if self.temporal_config is not None:
+            # Import lazily so the bot doesn't require the temporal package
+            # at import time if the feature is off.
+            from temporal.client import get_client
+
+            try:
+                self.temporal_client = await get_client(self.temporal_config)
+                logger.info(
+                    "Temporal client connected address=%s namespace=%s",
+                    self.temporal_config.address,
+                    self.temporal_config.namespace,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to connect Temporal client; bot will continue without it"
+                )
+        else:
+            logger.info("Temporal disabled (no TEMPORAL_ADDRESS configured).")
 
     async def on_ready(self):
         try:
@@ -79,5 +102,5 @@ class MyBot(discord.Client):
                 await message.channel.send(f"Error: {e}")
 
 
-def create_bot(chatbot, points_repo, db):
-    return MyBot(chatbot, points_repo, db)
+def create_bot(chatbot, points_repo, db, temporal_config=None):
+    return MyBot(chatbot, points_repo, db, temporal_config=temporal_config)

--- a/denjamin.py
+++ b/denjamin.py
@@ -13,12 +13,18 @@ from ai import ClaudeHandler
 from db import Database
 from points import PointsRepository
 from bot import create_bot
+from temporal import TemporalConfig
 
 # Initialize dependencies
 chatbot = ClaudeHandler(os.getenv("ANTHROPIC_API_KEY"))
 db = Database(os.getenv("DATABASE_URL"))
 points_repo = PointsRepository(db)
 
+# Temporal is opt-in: only wire it up if TEMPORAL_ADDRESS is set. The actual
+# connection happens asynchronously inside the bot's setup_hook so it lives
+# on the Discord event loop.
+temporal_config = TemporalConfig.from_env() if os.getenv("TEMPORAL_ADDRESS") else None
+
 # Create and run the bot
-bot = create_bot(chatbot, points_repo, db)
+bot = create_bot(chatbot, points_repo, db, temporal_config=temporal_config)
 bot.run(os.getenv("BOT_TOKEN"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,73 @@ services:
     profiles:
       - bot
 
+  # ----- Temporal stack (opt-in via --profile temporal) -----
+  # Dedicated Postgres for Temporal's persistence. Kept isolated from the app
+  # `db` service so Temporal schema upgrades don't touch application data.
+  temporal-postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: temporal
+      POSTGRES_PASSWORD: temporal
+      POSTGRES_DB: temporal
+    volumes:
+      - temporal-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U temporal"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    profiles:
+      - temporal
+
+  # Temporal server in "auto-setup" mode — creates the default namespace and
+  # schema on first boot. Fine for dev; for prod we recommend splitting into
+  # frontend/history/matching/internal-frontend services (see README).
+  temporal:
+    image: temporalio/auto-setup:1.25.2.0
+    environment:
+      DB: postgres12
+      DB_PORT: 5432
+      POSTGRES_USER: temporal
+      POSTGRES_PWD: temporal
+      POSTGRES_SEEDS: temporal-postgres
+    ports:
+      - "7233:7233"
+    depends_on:
+      temporal-postgres:
+        condition: service_healthy
+    profiles:
+      - temporal
+
+  # Web UI at http://localhost:8080
+  temporal-ui:
+    image: temporalio/ui:2.31.2
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_CORS_ORIGINS: http://localhost:3000
+    ports:
+      - "8080:8080"
+    depends_on:
+      - temporal
+    profiles:
+      - temporal
+
+  # Worker process: same image as `bot`, different entrypoint. In prod this is
+  # the deployable you scale horizontally when workflow throughput grows.
+  temporal-worker:
+    build: .
+    env_file: .env
+    command: python temporal_worker.py
+    environment:
+      # Override the host-facing default from .env so the worker reaches
+      # the Temporal server over the compose network.
+      TEMPORAL_ADDRESS: temporal:7233
+    stop_grace_period: 10s
+    depends_on:
+      - temporal
+    profiles:
+      - temporal
+
 volumes:
   pgdata:
+  temporal-pgdata:

--- a/temporal/__init__.py
+++ b/temporal/__init__.py
@@ -1,0 +1,4 @@
+from temporal.client import get_client
+from temporal.config import TemporalConfig
+
+__all__ = ["TemporalConfig", "get_client"]

--- a/temporal/activities.py
+++ b/temporal/activities.py
@@ -1,0 +1,14 @@
+"""Temporal activities.
+
+Activities are plain async functions executed by a worker. They're where
+side effects and non-deterministic code live (network calls, DB writes, etc.).
+"""
+
+from temporalio import activity
+
+
+@activity.defn
+async def say_hello(name: str) -> str:
+    """Starter activity used to smoke-test the Temporal stack end-to-end."""
+    activity.logger.info("say_hello invoked name=%s", name)
+    return f"Hello, {name}!"

--- a/temporal/client.py
+++ b/temporal/client.py
@@ -1,0 +1,39 @@
+"""Factory for constructing a connected Temporal client.
+
+Both the Discord bot process (to start workflows) and the worker process
+(to poll task queues) acquire their client through ``get_client``.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from temporalio.client import Client, TLSConfig
+
+from temporal.config import TemporalConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def get_client(config: Optional[TemporalConfig] = None) -> Client:
+    """Connect to the Temporal server described by ``config`` (or env)."""
+    config = config or TemporalConfig.from_env()
+
+    tls: "bool | TLSConfig" = False
+    if config.tls_enabled:
+        tls = TLSConfig(
+            client_cert=Path(config.tls_cert_path).read_bytes(),
+            client_private_key=Path(config.tls_key_path).read_bytes(),
+        )
+
+    logger.info(
+        "Connecting Temporal client: address=%s namespace=%s tls=%s",
+        config.address,
+        config.namespace,
+        config.tls_enabled,
+    )
+    return await Client.connect(
+        config.address,
+        namespace=config.namespace,
+        tls=tls,
+    )

--- a/temporal/config.py
+++ b/temporal/config.py
@@ -1,0 +1,36 @@
+"""Temporal client/worker configuration.
+
+Reads connection details from environment variables. All fields have sensible
+defaults for local development against a docker-compose Temporal stack.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_ADDRESS = "localhost:7233"
+DEFAULT_NAMESPACE = "default"
+DEFAULT_TASK_QUEUE = "denjamin-main"
+
+
+@dataclass(frozen=True)
+class TemporalConfig:
+    address: str = DEFAULT_ADDRESS
+    namespace: str = DEFAULT_NAMESPACE
+    task_queue: str = DEFAULT_TASK_QUEUE
+    tls_cert_path: Optional[str] = None
+    tls_key_path: Optional[str] = None
+
+    @classmethod
+    def from_env(cls) -> "TemporalConfig":
+        return cls(
+            address=os.getenv("TEMPORAL_ADDRESS", DEFAULT_ADDRESS),
+            namespace=os.getenv("TEMPORAL_NAMESPACE", DEFAULT_NAMESPACE),
+            task_queue=os.getenv("TEMPORAL_TASK_QUEUE", DEFAULT_TASK_QUEUE),
+            tls_cert_path=os.getenv("TEMPORAL_TLS_CERT_PATH") or None,
+            tls_key_path=os.getenv("TEMPORAL_TLS_KEY_PATH") or None,
+        )
+
+    @property
+    def tls_enabled(self) -> bool:
+        return bool(self.tls_cert_path and self.tls_key_path)

--- a/temporal/worker.py
+++ b/temporal/worker.py
@@ -1,0 +1,35 @@
+"""Temporal worker runner.
+
+Workers are long-running processes that poll a task queue on the Temporal
+server and execute registered workflows/activities. This module is invoked
+by the ``temporal_worker.py`` root entrypoint.
+"""
+
+import asyncio
+import logging
+
+from temporalio.worker import Worker
+
+from temporal.activities import say_hello
+from temporal.client import get_client
+from temporal.config import TemporalConfig
+from temporal.workflows import HelloWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+async def run() -> None:
+    config = TemporalConfig.from_env()
+    client = await get_client(config)
+    logger.info("Temporal worker starting task_queue=%s", config.task_queue)
+    worker = Worker(
+        client,
+        task_queue=config.task_queue,
+        workflows=[HelloWorkflow],
+        activities=[say_hello],
+    )
+    await worker.run()
+
+
+def main() -> None:
+    asyncio.run(run())

--- a/temporal/workflows.py
+++ b/temporal/workflows.py
@@ -1,0 +1,25 @@
+"""Temporal workflow definitions.
+
+Workflows must be deterministic: no wall-clock time, no random numbers,
+no direct IO. They orchestrate activities, which do the real work.
+"""
+
+from datetime import timedelta
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from temporal.activities import say_hello
+
+
+@workflow.defn
+class HelloWorkflow:
+    """Starter workflow: calls ``say_hello`` and returns its result."""
+
+    @workflow.run
+    async def run(self, name: str) -> str:
+        return await workflow.execute_activity(
+            say_hello,
+            name,
+            start_to_close_timeout=timedelta(seconds=10),
+        )

--- a/temporal_worker.py
+++ b/temporal_worker.py
@@ -1,0 +1,21 @@
+"""Root entrypoint for the Temporal worker process.
+
+Runs as its own container/process — separate from the Discord bot. Both share
+the same Docker image and codebase; only the entrypoint differs.
+"""
+
+import logging
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+from temporal.worker import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/temporal/test_config.py
+++ b/tests/temporal/test_config.py
@@ -1,0 +1,49 @@
+import pytest
+
+from temporal.config import (
+    DEFAULT_ADDRESS,
+    DEFAULT_NAMESPACE,
+    DEFAULT_TASK_QUEUE,
+    TemporalConfig,
+)
+
+
+def test_from_env_defaults(monkeypatch):
+    for var in (
+        "TEMPORAL_ADDRESS",
+        "TEMPORAL_NAMESPACE",
+        "TEMPORAL_TASK_QUEUE",
+        "TEMPORAL_TLS_CERT_PATH",
+        "TEMPORAL_TLS_KEY_PATH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    config = TemporalConfig.from_env()
+    assert config.address == DEFAULT_ADDRESS
+    assert config.namespace == DEFAULT_NAMESPACE
+    assert config.task_queue == DEFAULT_TASK_QUEUE
+    assert config.tls_cert_path is None
+    assert config.tls_key_path is None
+    assert config.tls_enabled is False
+
+
+def test_from_env_overrides(monkeypatch):
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "temporal.prod:7233")
+    monkeypatch.setenv("TEMPORAL_NAMESPACE", "denjamin-prod")
+    monkeypatch.setenv("TEMPORAL_TASK_QUEUE", "denjamin-prod-main")
+    monkeypatch.setenv("TEMPORAL_TLS_CERT_PATH", "/certs/client.pem")
+    monkeypatch.setenv("TEMPORAL_TLS_KEY_PATH", "/certs/client.key")
+
+    config = TemporalConfig.from_env()
+    assert config.address == "temporal.prod:7233"
+    assert config.namespace == "denjamin-prod"
+    assert config.task_queue == "denjamin-prod-main"
+    assert config.tls_cert_path == "/certs/client.pem"
+    assert config.tls_key_path == "/certs/client.key"
+    assert config.tls_enabled is True
+
+
+def test_tls_enabled_requires_both_paths(monkeypatch):
+    monkeypatch.setenv("TEMPORAL_TLS_CERT_PATH", "/certs/client.pem")
+    monkeypatch.delenv("TEMPORAL_TLS_KEY_PATH", raising=False)
+    assert TemporalConfig.from_env().tls_enabled is False

--- a/tests/temporal/test_workflows.py
+++ b/tests/temporal/test_workflows.py
@@ -1,0 +1,34 @@
+"""Integration tests for Temporal workflows.
+
+Uses WorkflowEnvironment's time-skipping test server (bundled with the
+temporalio SDK). No docker containers required — runs in a subprocess.
+"""
+
+import uuid
+
+import pytest
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from temporal.activities import say_hello
+from temporal.workflows import HelloWorkflow
+
+
+@pytest.mark.asyncio
+async def test_hello_workflow_end_to_end():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        task_queue = f"test-{uuid.uuid4()}"
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[HelloWorkflow],
+            activities=[say_hello],
+        ):
+            result = await env.client.execute_workflow(
+                HelloWorkflow.run,
+                "Denjamin",
+                id=f"hello-{uuid.uuid4()}",
+                task_queue=task_queue,
+            )
+
+    assert result == "Hello, Denjamin!"


### PR DESCRIPTION
## Summary
- Adds a `temporal/` Python package with a client factory, starter `HelloWorkflow` + `say_hello` activity, and a worker runner. Worker ships as its own process via a new `temporal_worker.py` root entrypoint that reuses the bot's Docker image.
- Opt-in wiring in `denjamin.py`: when `TEMPORAL_ADDRESS` is set, a `TemporalConfig` is passed into `create_bot(...)` and the bot lazily connects a client in `setup_hook()` so it lives on Discord's event loop. Connection failures are logged but non-fatal.
- `docker-compose.yml` gains a `temporal` profile bringing up `temporalio/auto-setup`, `temporalio/ui`, a dedicated `temporal-postgres`, and a `temporal-worker` service (same image as `bot`, different `command`).
- Integration test uses `WorkflowEnvironment.start_time_skipping()` to execute the starter workflow end-to-end without needing docker in CI.
- README documents both the dev bring-up and production (self-hosted, Raspberry Pi-leaning) notes.

Closes #45

## Test plan
- [x] `pytest` — 65 passed (61 existing + 4 new)
- [x] `docker compose --profile bot --profile temporal config` renders cleanly
- [ ] `docker compose --profile temporal up` locally — Temporal UI reachable at http://localhost:8080, worker connects to the task queue
- [ ] From a REPL with `TEMPORAL_ADDRESS=localhost:7233` set, start `HelloWorkflow` via the client factory and confirm `"Hello, Denjamin!"` is returned
- [ ] Bring up the bot with `TEMPORAL_ADDRESS` unset — confirm it still runs (Temporal log line: "Temporal disabled")

🤖 Generated with [Claude Code](https://claude.com/claude-code)