### PR TITLE
Add DOCKER.md reference and slim Docker sections in README

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,164 @@
+# Docker Cheat Sheet
+
+A practical reference for the Docker commands you'll actually use while working on Denjamin. The main [README](README.md) has the quickstart — this doc fills in the day-to-day operations.
+
+All commands assume you're running them from the repo root.
+
+## Services at a glance
+
+Defined in [docker-compose.yml](docker-compose.yml):
+
+| Service             | Profile     | Port(s)            | Purpose                                 |
+|---------------------|-------------|--------------------|-----------------------------------------|
+| `db`                | *(default)* | `5432`             | App Postgres — bot data, points         |
+| `bot`               | `bot`       | —                  | The Discord bot process                 |
+| `temporal-postgres` | `temporal`  | —                  | Dedicated Postgres for Temporal         |
+| `temporal`          | `temporal`  | `7233`             | Temporal server (auto-setup, dev only)  |
+| `temporal-ui`       | `temporal`  | `8080`             | Temporal Web UI                         |
+| `temporal-worker`   | `temporal`  | —                  | Worker process (same image as `bot`)    |
+
+Services without a profile start by default. Profiled services only start when you pass `--profile <name>` (or `COMPOSE_PROFILES=<name>`).
+
+## Common workflows
+
+### Just Postgres (bot runs locally via `python denjamin.py`)
+
+```bash
+docker compose up -d                  # start db in background
+docker compose ps                     # verify it's healthy
+docker compose logs -f db             # tail logs
+docker compose down                   # stop (keeps data)
+```
+
+### Full bot in a container
+
+```bash
+docker compose --profile bot up       # attached; Ctrl-C to stop
+docker compose --profile bot up -d    # detached
+docker compose --profile bot logs -f  # tail all profile services
+```
+
+### Full Temporal stack
+
+```bash
+docker compose --profile temporal up -d
+open http://localhost:8080            # Temporal Web UI
+docker compose --profile temporal down
+```
+
+### Everything at once (bot + temporal)
+
+```bash
+docker compose --profile bot --profile temporal up -d
+```
+
+### Temporal infra only (no worker — useful when iterating on workflow code from a REPL or running the worker locally)
+
+```bash
+docker compose up -d temporal temporal-ui temporal-postgres
+```
+
+## Rebuilding after code or dependency changes
+
+The `bot` and `temporal-worker` services share one image built from the [Dockerfile](Dockerfile). Anything that changes `requirements.txt` or application code means a rebuild.
+
+```bash
+docker compose build                        # rebuild all buildable services
+docker compose build bot                    # rebuild just one
+docker compose --profile bot up --build     # rebuild then start
+docker compose build --no-cache bot         # force full rebuild (slow; for pip weirdness)
+```
+
+## Inspecting running services
+
+```bash
+docker compose ps                     # running services + health
+docker compose logs -f <service>      # tail one service
+docker compose logs --tail=200 bot    # last 200 lines, no follow
+docker compose top                    # processes inside each container
+docker compose config                 # render the effective merged config
+```
+
+## Running commands inside containers
+
+```bash
+# Open a shell in the bot container (must be running)
+docker compose exec bot bash
+
+# Run a one-off command in a fresh bot container (no need for it to be up)
+docker compose run --rm bot python -c "import denjamin; print('ok')"
+
+# Run the test suite inside the image
+docker compose run --rm bot pytest
+```
+
+## Accessing Postgres
+
+```bash
+# psql into the app DB
+docker compose exec db psql -U denbot -d denbot
+
+# One-off query
+docker compose exec db psql -U denbot -d denbot -c "select count(*) from points;"
+
+# Dump / restore
+docker compose exec db pg_dump -U denbot denbot > denbot.sql
+cat denbot.sql | docker compose exec -T db psql -U denbot -d denbot
+
+# Re-apply schema.sql (only runs automatically on *empty* volume)
+docker compose exec -T db psql -U denbot -d denbot < db/schema.sql
+```
+
+Temporal's Postgres is the same deal with different creds:
+
+```bash
+docker compose exec temporal-postgres psql -U temporal -d temporal
+```
+
+## Volumes and data
+
+Two named volumes hold persistent state: `pgdata` (app) and `temporal-pgdata` (Temporal).
+
+```bash
+docker volume ls | grep den-bot             # list project volumes
+docker compose down                         # stop containers, KEEP volumes
+docker compose down -v                      # stop and WIPE all volumes (destructive)
+docker volume rm den-bot_pgdata             # wipe just the app DB (destructive)
+```
+
+Note: `db/schema.sql` is only applied by the Postgres image on an *empty* data directory. If you change the schema, either apply the diff manually via `psql` or wipe `pgdata` to trigger a fresh init.
+
+## Restarting and stopping
+
+```bash
+docker compose restart bot            # restart one service
+docker compose stop                   # stop everything, keep containers
+docker compose start                  # start stopped containers back up
+docker compose kill bot               # SIGKILL (when stop grace period isn't cutting it)
+```
+
+The `bot` and `temporal-worker` services set `stop_grace_period: 10s` — they'll get SIGTERM, have 10s to clean up, then SIGKILL.
+
+## Troubleshooting
+
+**"port is already allocated"** — something else is using 5432, 7233, or 8080. Find it with `lsof -i :5432` and stop it, or stop the other stack: `docker compose down`.
+
+**Temporal worker crashing at startup** — the worker retries connecting for ~2 minutes and is set to `restart: unless-stopped`. If it's still failing after that, check `docker compose logs temporal` — the auto-setup image sometimes takes a while on the first boot while it provisions the schema.
+
+**Bot container can't reach the DB** — inside the compose network, use `db` as the host, not `localhost`. Your `.env` `DATABASE_URL` should be `postgresql://denbot:denbot@db:5432/denbot` when running the bot as a container (vs. `@localhost:5432` when running it on the host).
+
+**Same for Temporal** — inside the network it's `temporal:7233`; from the host it's `localhost:7233`. The compose file already overrides `TEMPORAL_ADDRESS=temporal:7233` for the worker service so you don't have to juggle this in `.env`.
+
+**Stale image after a dep change** — run `docker compose build bot` (or `--build` on `up`). `up` alone does not rebuild.
+
+**Disk filling up** — prune unused images/containers/volumes:
+
+```bash
+docker system df                      # see what's using space
+docker system prune                   # remove dangling images + stopped containers
+docker system prune --volumes         # also prune unused volumes (careful)
+```
+
+## `docker compose` vs `docker-compose`
+
+This doc uses the v2 `docker compose` (space) form that ships with modern Docker Desktop. If you're on an older install that only has `docker-compose` (hyphenated), the commands here work identically with the hyphen.

--- a/README.md
+++ b/README.md
@@ -61,46 +61,19 @@ This is a discord bot that will help you and your friends increase your denlines
 
 ## Docker
 
-Instead of installing PostgreSQL locally, you can use Docker:
+Instead of installing PostgreSQL locally, you can run Postgres (and optionally the bot itself) in Docker. See [DOCKER.md](DOCKER.md) for the full command reference — it covers lifecycle, rebuilds, volumes, psql access, and troubleshooting.
 
-**Start Postgres for local dev** (bot runs on your machine):
-
-```bash
-docker-compose up -d
-```
-
-This starts Postgres on `localhost:5432` and auto-creates the `points` table. Set your `DATABASE_URL` to `postgresql://denbot:denbot@localhost:5432/denbot`.
-
-**Run everything in containers** (Postgres + bot):
+Quickstart — start Postgres in the background and run the bot on your host:
 
 ```bash
-docker-compose --profile bot up
+docker compose up -d
 ```
 
-**Tear down and remove data:**
-
-```bash
-docker-compose down -v
-```
+Then set `DATABASE_URL=postgresql://denbot:denbot@localhost:5432/denbot` in your `.env`.
 
 ## Temporal (workflow orchestration)
 
-Denjamin ships with an opt-in Temporal stack for durable workflow execution. Temporal is gated behind a docker-compose profile so it only runs when you ask for it.
-
-**Bring up the full Temporal stack** (server, UI, its own Postgres, and a worker):
-
-```bash
-docker-compose --profile temporal up
-```
-
-- gRPC frontend: `localhost:7233`
-- Web UI: [http://localhost:8080](http://localhost:8080)
-
-**Run just Temporal without the bot or worker** (useful when developing workflows from a REPL):
-
-```bash
-docker-compose up temporal temporal-ui temporal-postgres
-```
+Denjamin ships with an opt-in Temporal stack for durable workflow execution, gated behind a `temporal` compose profile. See [DOCKER.md](DOCKER.md) for how to bring it up; the rest of this section is config and production notes.
 
 **Enable the Temporal client in the bot** by setting `TEMPORAL_ADDRESS` in your `.env`:
 


### PR DESCRIPTION
## Summary
- New [DOCKER.md](../blob/claude/busy-wozniak/DOCKER.md) at the repo root with a practical command reference: services table, common workflows per profile, rebuilds, container exec, psql access, volumes, and troubleshooting (port conflicts, network hostnames, stale images, disk pruning).
- Trimmed the `## Docker` and `## Temporal` sections of `README.md` down to a quickstart + pointer, and switched examples to the v2 `docker compose` (space) form for consistency with the new doc. The Temporal env-var config, local-worker instructions, and self-hosted production notes stay in the README since they're not Docker-command recipes.

## Test plan
- [ ] Render `README.md` and `DOCKER.md` on GitHub and confirm cross-links resolve
- [ ] Spot-check a few commands from `DOCKER.md` (`docker compose up -d`, `docker compose --profile temporal up -d`, `docker compose exec db psql ...`) against the live stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)