### PR TITLE
Fix points.sql syntax for aiosql 15.x

### DIFF
--- a/src/denbot/points/sql/points.sql
+++ b/src/denbot/points/sql/points.sql
@@ -1,11 +1,11 @@
--- name: get_user_points^
+-- name: get_user_points(user_id)^
 SELECT points FROM points WHERE user_id = :user_id;
 
--- name: update_user_points$
+-- name: update_user_points(points, display_name, user_id)$
 UPDATE points SET points = :points, display_name = :display_name WHERE user_id = :user_id;
 
--- name: insert_user!
+-- name: insert_user(user_id, username, display_name, points)!
 INSERT INTO points (user_id, username, display_name, points) VALUES (:user_id, :username, :display_name, :points);
 
--- name: get_leaderboard
+-- name: get_leaderboard()
 SELECT user_id, points FROM points ORDER BY points DESC;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,4 @@
-from unittest.mock import MagicMock, AsyncMock, patch
-
-# Patch aiosql.from_path before any test module imports points.repository,
-# which calls aiosql.from_path at module level. The locally installed aiosql
-# version may be incompatible with the project's SQL syntax, so we replace
-# the call with a MagicMock to avoid parse errors during test collection.
-_aiosql_patcher = patch("aiosql.from_path", return_value=MagicMock())
-_aiosql_patcher.start()
+from unittest.mock import MagicMock, AsyncMock
 
 import pytest
 


### PR DESCRIPTION
## Summary
- Add explicit parameter lists to each query in `src/denbot/points/sql/points.sql` so aiosql 15.x's stricter parser accepts the file (Option 2 from #50).
- Drop the `aiosql.from_path` MagicMock from `tests/conftest.py` so tests exercise real SQL parsing and catch this class of regression.

Closes #50

## Test plan
- [x] `uv run python -c \"from denbot.points.repository import PointsRepository\"` succeeds
- [x] `uv run python -c \"from denbot.bot.client import create_bot\"` succeeds
- [x] `uv run pytest` — 65 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)