### PR TITLE
Add Makefile wrapping dev commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,4 @@ jobs:
         with:
           python-version: "3.12"
       - run: uv sync --group dev
-      - run: uv run ruff check src tests
-      - run: uv run ruff format --check src tests
+      - run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: all check lint format fix test
+
+all: check test
+
+check:
+	uv run ruff check src tests
+	uv run ruff format --check src tests
+
+lint:
+	uv run ruff check src tests
+
+fix:
+	uv run ruff check --fix src tests
+
+format:
+	uv run ruff format src tests
+
+test:
+	uv run pytest

--- a/README.md
+++ b/README.md
@@ -110,22 +110,19 @@ The `temporalio/auto-setup` image we use for dev is explicitly not recommended b
    - Select permissions: `Send Messages`, `Read Message History`
 6. Open the generated URL to invite the bot to a test Discord server
 
-## Running Tests
+## Dev workflow
+
+Common tasks are wrapped in a `Makefile`:
 
 ```bash
-uv run pytest
+make check    # lint + format-check (what CI runs — read-only)
+make test     # run pytest
+make all      # check + test (default target)
+make fix      # auto-fix lint issues
+make format   # reformat files in place
+make lint     # lint only
 ```
 
-Tests use mocked Discord, database, and Anthropic connections — no real services needed. If you haven't installed dev deps yet, run `uv sync --group dev` first.
+Underneath it's all `uv run ruff …` and `uv run pytest` — see the [Makefile](Makefile) for the exact commands. Tests use mocked Discord, database, and Anthropic connections, so no real services are needed. If you haven't installed dev deps yet, run `uv sync --group dev` first.
 
-## Linting and formatting
-
-This project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting.
-
-```bash
-uv run ruff check src tests          # report issues
-uv run ruff check --fix src tests    # auto-fix what it can
-uv run ruff format src tests         # format in place
-```
-
-CI runs `ruff check` and `ruff format --check` on every PR — a style violation fails the build.
+Linting and formatting are powered by [ruff](https://docs.astral.sh/ruff/). CI runs `make check` on every PR — a style violation fails the build.


### PR DESCRIPTION
## Summary

Wraps the `uv run ruff …` and `uv run pytest` incantations behind a small `Makefile` so you don't have to remember flags and paths. Follow-up to #54.

Targets:

| target | what it does |
| --- | --- |
| `make all` (default) | `check` + `test` |
| `make check` | `ruff check` + `ruff format --check` — what CI runs, read-only |
| `make lint` | `ruff check` only |
| `make fix` | `ruff check --fix` — auto-fix what's fixable |
| `make format` | `ruff format` — rewrite files |
| `make test` | `pytest` |

CI's lint workflow now calls `make check` instead of two hard-coded ruff invocations, so the canonical command list lives in one place.

## Test plan

- [x] `make check` — clean
- [x] `make test` — 65/65 pass
- [x] `make lint`, `make fix`, `make format` run and do what the target names imply
- [ ] CI "Lint" job passes using `make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)